### PR TITLE
Upgrade to Netty 4.1.5.Final and Akka Streams 2.4.10

### DIFF
--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-reactive-streams-http</artifactId>

--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams-parent</artifactId>
-        <version>1.0.9-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-reactive-streams-http</artifactId>

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateHttpMessage.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateHttpMessage.java
@@ -12,8 +12,14 @@ class DelegateHttpMessage implements HttpMessage {
     }
 
     @Override
+    @Deprecated
     public HttpVersion getProtocolVersion() {
-        return message.getProtocolVersion();
+        return message.protocolVersion();
+    }
+
+    @Override
+    public HttpVersion protocolVersion() {
+        return message.protocolVersion();
     }
 
     @Override
@@ -28,8 +34,14 @@ class DelegateHttpMessage implements HttpMessage {
     }
 
     @Override
+    @Deprecated
     public DecoderResult getDecoderResult() {
-        return message.getDecoderResult();
+        return message.decoderResult();
+    }
+
+    @Override
+    public DecoderResult decoderResult() {
+        return message.decoderResult();
     }
 
     @Override

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateHttpRequest.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateHttpRequest.java
@@ -1,10 +1,8 @@
 package com.typesafe.netty.http;
 
-import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
-import org.reactivestreams.Publisher;
 
 class DelegateHttpRequest extends DelegateHttpMessage implements HttpRequest {
 
@@ -28,13 +26,25 @@ class DelegateHttpRequest extends DelegateHttpMessage implements HttpRequest {
     }
 
     @Override
+    @Deprecated
     public HttpMethod getMethod() {
-        return request.getMethod();
+        return request.method();
     }
 
     @Override
+    public HttpMethod method() {
+        return request.method();
+    }
+
+    @Override
+    @Deprecated
     public String getUri() {
-        return request.getUri();
+        return request.uri();
+    }
+
+    @Override
+    public String uri() {
+        return request.uri();
     }
 
     @Override

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateHttpResponse.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateHttpResponse.java
@@ -1,10 +1,8 @@
 package com.typesafe.netty.http;
 
-import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import org.reactivestreams.Publisher;
 
 class DelegateHttpResponse extends DelegateHttpMessage implements HttpResponse {
 
@@ -22,8 +20,14 @@ class DelegateHttpResponse extends DelegateHttpMessage implements HttpResponse {
     }
 
     @Override
+    @Deprecated
     public HttpResponseStatus getStatus() {
-        return response.getStatus();
+        return response.status();
+    }
+
+    @Override
+    public HttpResponseStatus status() {
+        return response.status();
     }
 
     @Override

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateStreamedHttpRequest.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateStreamedHttpRequest.java
@@ -1,9 +1,7 @@
 package com.typesafe.netty.http;
 
 import io.netty.handler.codec.http.HttpContent;
-import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpVersion;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateStreamedHttpResponse.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/DelegateStreamedHttpResponse.java
@@ -2,8 +2,6 @@ package com.typesafe.netty.http;
 
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpVersion;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/EmptyHttpRequest.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/EmptyHttpRequest.java
@@ -35,7 +35,7 @@ class EmptyHttpRequest extends DelegateHttpRequest implements FullHttpRequest {
         if (request instanceof FullHttpRequest) {
             return new EmptyHttpRequest(((FullHttpRequest) request).copy());
         } else {
-            DefaultHttpRequest copy = new DefaultHttpRequest(getProtocolVersion(), getMethod(), getUri());
+            DefaultHttpRequest copy = new DefaultHttpRequest(protocolVersion(), method(), uri());
             copy.headers().set(headers());
             return new EmptyHttpRequest(copy);
         }
@@ -54,14 +54,50 @@ class EmptyHttpRequest extends DelegateHttpRequest implements FullHttpRequest {
     }
 
     @Override
+    public FullHttpRequest touch() {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).touch();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpRequest touch(Object o) {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).touch(o);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
     public HttpHeaders trailingHeaders() {
         return new DefaultHttpHeaders();
     }
 
     @Override
-    public HttpContent duplicate() {
-        if (request instanceof HttpContent) {
-            return ((HttpContent) request).duplicate();
+    public FullHttpRequest duplicate() {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).duplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpRequest retainedDuplicate() {
+        if (request instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).retainedDuplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpRequest replace(ByteBuf byteBuf) {
+        if (message instanceof FullHttpRequest) {
+            return ((FullHttpRequest) request).replace(byteBuf);
         } else {
             return this;
         }

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/EmptyHttpResponse.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/EmptyHttpResponse.java
@@ -29,7 +29,7 @@ class EmptyHttpResponse extends DelegateHttpResponse implements FullHttpResponse
         if (response instanceof FullHttpResponse) {
             return new EmptyHttpResponse(((FullHttpResponse) response).copy());
         } else {
-            DefaultHttpResponse copy = new DefaultHttpResponse(getProtocolVersion(), getStatus());
+            DefaultHttpResponse copy = new DefaultHttpResponse(protocolVersion(), status());
             copy.headers().set(headers());
             return new EmptyHttpResponse(copy);
         }
@@ -48,14 +48,50 @@ class EmptyHttpResponse extends DelegateHttpResponse implements FullHttpResponse
     }
 
     @Override
+    public FullHttpResponse touch() {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).touch();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpResponse touch(Object o) {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).touch(o);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
     public HttpHeaders trailingHeaders() {
         return new DefaultHttpHeaders();
     }
 
     @Override
-    public HttpContent duplicate() {
-        if (response instanceof HttpContent) {
-            return ((HttpContent) response).duplicate();
+    public FullHttpResponse duplicate() {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).duplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpResponse retainedDuplicate() {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).retainedDuplicate();
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public FullHttpResponse replace(ByteBuf byteBuf) {
+        if (response instanceof FullHttpResponse) {
+            return ((FullHttpResponse) response).replace(byteBuf);
         } else {
             return this;
         }

--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsClientHandler.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsClientHandler.java
@@ -42,22 +42,22 @@ public class HttpStreamsClientHandler extends HttpStreamsHandler<HttpResponse, H
 
     @Override
     protected boolean hasBody(HttpResponse response) {
-        if (response.getStatus().code() >= 100 && response.getStatus().code() < 200) {
+        if (response.status().code() >= 100 && response.status().code() < 200) {
             return false;
         }
 
-        if (response.getStatus().equals(HttpResponseStatus.NO_CONTENT) ||
-                response.getStatus().equals(HttpResponseStatus.NOT_MODIFIED)) {
+        if (response.status().equals(HttpResponseStatus.NO_CONTENT) ||
+                response.status().equals(HttpResponseStatus.NOT_MODIFIED)) {
             return false;
         }
 
-        if (HttpHeaders.isTransferEncodingChunked(response)) {
+        if (HttpUtil.isTransferEncodingChunked(response)) {
             return true;
         }
 
 
-        if (HttpHeaders.isContentLengthSet(response)) {
-            return HttpHeaders.getContentLength(response) > 0;
+        if (HttpUtil.isContentLengthSet(response)) {
+            return HttpUtil.getContentLength(response) > 0;
         }
 
         return true;
@@ -103,7 +103,7 @@ public class HttpStreamsClientHandler extends HttpStreamsHandler<HttpResponse, H
 
     @Override
     protected void subscribeSubscriberToStream(StreamedHttpMessage msg, Subscriber<HttpContent> subscriber) {
-        if (HttpHeaders.is100ContinueExpected(msg)) {
+        if (HttpUtil.is100ContinueExpected(msg)) {
             awaiting100Continue = subscriber;
             awaiting100ContinueMessage = msg;
         } else {
@@ -116,7 +116,7 @@ public class HttpStreamsClientHandler extends HttpStreamsHandler<HttpResponse, H
 
         if (msg instanceof HttpResponse && awaiting100Continue != null && withServer == 0) {
             HttpResponse response = (HttpResponse) msg;
-            if (response.getStatus().equals(HttpResponseStatus.CONTINUE)) {
+            if (response.status().equals(HttpResponseStatus.CONTINUE)) {
                 super.subscribeSubscriberToStream(awaiting100ContinueMessage, awaiting100Continue);
                 awaiting100Continue = null;
                 awaiting100ContinueMessage = null;

--- a/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/HttpStreamsTest.java
+++ b/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/HttpStreamsTest.java
@@ -57,7 +57,7 @@ public class HttpStreamsTest {
         assertEquals(helper.getRequestContentLength(response), 11);
 
         assertEquals(helper.extractBody(response), "hello world");
-        assertEquals(HttpHeaders.getContentLength(response), 11);
+        assertEquals(HttpUtil.getContentLength(response), 11);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class HttpStreamsTest {
         assertFalse(helper.hasRequestContentLength(response));
 
         assertEquals(helper.extractBody(response), "hello world");
-        assertTrue(HttpHeaders.isTransferEncodingChunked(response));
+        assertTrue(HttpUtil.isTransferEncodingChunked(response));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class HttpStreamsTest {
         assertFalse(helper.hasRequestContentLength(response));
 
         assertEquals(helper.extractBody(response), "");
-        assertEquals(HttpHeaders.getContentLength(response), 0);
+        assertEquals(HttpUtil.getContentLength(response), 0);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class HttpStreamsTest {
         assertEquals(helper.getRequestContentLength(response), 0);
 
         assertEquals(helper.extractBody(response), "");
-        assertEquals(HttpHeaders.getContentLength(response), 0);
+        assertEquals(HttpUtil.getContentLength(response), 0);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class HttpStreamsTest {
         client.writeAndFlush(helper.createStreamedRequest("GET", "/", Collections.<String>emptyList()));
         StreamedHttpResponse response = receiveStreamedResponse();
 
-        assertFalse(HttpHeaders.isContentLengthSet(response));
+        assertFalse(HttpUtil.isContentLengthSet(response));
         assertEquals(helper.extractBody(response), "hello world");
 
         client.closeFuture().await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -120,7 +120,7 @@ public class HttpStreamsTest {
         client.writeAndFlush(helper.createStreamedRequest("GET", "/", Collections.<String>emptyList()));
         FullHttpResponse response = receiveFullResponse();
 
-        assertFalse(HttpHeaders.isContentLengthSet(response));
+        assertFalse(HttpUtil.isContentLengthSet(response));
         assertEquals(helper.extractBody(response), "");
 
         client.closeFuture().await(TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -134,7 +134,7 @@ public class HttpStreamsTest {
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 if (msg instanceof StreamedHttpRequest) {
                     StreamedHttpRequest request = (StreamedHttpRequest) msg;
-                    if (request.getUri().equals("/cancel")) {
+                    if (request.uri().equals("/cancel")) {
                         helper.cancelStreamedMessage(request);
                         HttpResponse response = helper.createFullResponse("");
                         response.headers().set("Cancelled", true);
@@ -189,7 +189,7 @@ public class HttpStreamsTest {
             }
         });
         StreamedHttpRequest request = helper.createStreamedRequest("POST", "/", Arrays.asList("hello", " ", "world"), 11);
-        HttpHeaders.set100ContinueExpected(request);
+        HttpUtil.set100ContinueExpected(request, true);
         client.writeAndFlush(request);
 
         StreamedHttpResponse response = receiveStreamedResponse();
@@ -210,7 +210,7 @@ public class HttpStreamsTest {
             }
         });
         StreamedHttpRequest request = helper.createStreamedRequest("POST", "/", Arrays.asList("hello", " ", "world"), 11);
-        HttpHeaders.set100ContinueExpected(request);
+        HttpUtil.set100ContinueExpected(request, true);
         client.writeAndFlush(request);
 
         StreamedHttpResponse response = receiveStreamedResponse();
@@ -249,12 +249,12 @@ public class HttpStreamsTest {
         client.writeAndFlush(helper.createStreamedRequest("POST", "/", Collections.singletonList("request 1"), 9));
         client.writeAndFlush(helper.createStreamedRequest("POST", "/", Collections.singletonList("request 2"), 9));
         StreamedHttpRequest request3 = helper.createStreamedRequest("POST", "/", Collections.singletonList("request 3"), 9);
-        HttpHeaders.set100ContinueExpected(request3);
+        HttpUtil.set100ContinueExpected(request3, true);
         client.writeAndFlush(request3);
         client.writeAndFlush(helper.createStreamedRequest("POST", "/", Collections.singletonList("request 4"), 9));
         client.writeAndFlush(helper.createStreamedRequest("POST", "/", Collections.singletonList("request 5"), 9));
         StreamedHttpRequest request6 = helper.createStreamedRequest("POST", "/", Collections.singletonList("request 6"), 9);
-        HttpHeaders.set100ContinueExpected(request6);
+        HttpUtil.set100ContinueExpected(request6, true);
         client.writeAndFlush(request6);
 
         assertEquals(helper.extractBody(receiveStreamedResponse()), "request 1");
@@ -309,7 +309,7 @@ public class HttpStreamsTest {
             @Override
             public void channelRead(final ChannelHandlerContext ctx, Object msg) throws Exception {
                 HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_0, HttpResponseStatus.OK);
-                HttpHeaders.setContentLength(response, 0);
+                HttpUtil.setContentLength(response, 0);
                 ctx.writeAndFlush(response);
             }
         });

--- a/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/WebSocketsTest.java
+++ b/netty-reactive-streams-http/src/test/java/com/typesafe/netty/http/WebSocketsTest.java
@@ -67,7 +67,7 @@ public class WebSocketsTest {
                         }
                     }).toProcessor().run(materializer);
 
-                    ctx.writeAndFlush(new DefaultWebSocketHttpResponse(request.getProtocolVersion(),
+                    ctx.writeAndFlush(new DefaultWebSocketHttpResponse(request.protocolVersion(),
                             HttpResponseStatus.valueOf(200), processor,
                             new WebSocketServerHandshakerFactory("ws://127.0.0.1/" + port + "/", null, false)
                     ));
@@ -118,7 +118,7 @@ public class WebSocketsTest {
 
                     Processor<WebSocketFrame, WebSocketFrame> processor = Flow.<WebSocketFrame>create().toProcessor().run(materializer);
 
-                    ctx.writeAndFlush(new DefaultWebSocketHttpResponse(request.getProtocolVersion(),
+                    ctx.writeAndFlush(new DefaultWebSocketHttpResponse(request.protocolVersion(),
                             HttpResponseStatus.valueOf(200), processor,
                             new WebSocketServerHandshakerFactory("ws://127.0.0.1/" + port + "/", null, false)
                     ));
@@ -128,17 +128,17 @@ public class WebSocketsTest {
 
         FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         HttpHeaders headers = request.headers();
-        headers.add(HttpHeaders.Names.UPGRADE, HttpHeaders.Values.WEBSOCKET.toLowerCase())
-                .add(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.UPGRADE)
-                .add(HttpHeaders.Names.SEC_WEBSOCKET_KEY, "foobar")
-                .add(HttpHeaders.Names.HOST, "http://127.0.0.1:" + port)
-                .add(HttpHeaders.Names.SEC_WEBSOCKET_ORIGIN, "http://127.0.0.1:" + port)
-                .add(HttpHeaders.Names.SEC_WEBSOCKET_VERSION, "1");
+        headers.add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET.toLowerCase())
+                .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
+                .add(HttpHeaderNames.SEC_WEBSOCKET_KEY, "foobar")
+                .add(HttpHeaderNames.HOST, "http://127.0.0.1:" + port)
+                .add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://127.0.0.1:" + port)
+                .add(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "1");
         client.writeAndFlush(request);
 
         FullHttpResponse response = receiveFullResponse();
-        assertEquals(response.getStatus(), HttpResponseStatus.UPGRADE_REQUIRED);
-        assertEquals(response.headers().get(HttpHeaders.Names.SEC_WEBSOCKET_VERSION), "13");
+        assertEquals(response.status(), HttpResponseStatus.UPGRADE_REQUIRED);
+        assertEquals(response.headers().get(HttpHeaderNames.SEC_WEBSOCKET_VERSION), "13");
         ReferenceCountUtil.release(response);
     }
 

--- a/netty-reactive-streams/pom.xml
+++ b/netty-reactive-streams/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams-parent</artifactId>
-        <version>1.0.9-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-reactive-streams</artifactId>

--- a/netty-reactive-streams/pom.xml
+++ b/netty-reactive-streams/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams-parent</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-reactive-streams</artifactId>

--- a/netty-reactive-streams/src/test/java/com/typesafe/netty/HandlerPublisherVerificationTest.java
+++ b/netty-reactive-streams/src/test/java/com/typesafe/netty/HandlerPublisherVerificationTest.java
@@ -2,8 +2,8 @@ package com.typesafe.netty;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.local.LocalChannel;
-import io.netty.channel.local.LocalEventLoopGroup;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
@@ -24,7 +24,7 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
     private final boolean scheduled;
 
     private ScheduledExecutorService executor;
-    private LocalEventLoopGroup eventLoop;
+    private DefaultEventLoopGroup eventLoop;
 
     // For debugging, change the data provider to simple, and adjust the parameters below
     @Factory(dataProvider = "noScheduled")
@@ -74,7 +74,7 @@ public class HandlerPublisherVerificationTest extends PublisherVerification<Long
     // doesn't happen if you create 32 publishers in a single test.
     @BeforeMethod
     public void startEventLoop() {
-        eventLoop = new LocalEventLoopGroup();
+        eventLoop = new DefaultEventLoopGroup();
     }
 
     @AfterMethod

--- a/netty-reactive-streams/src/test/java/com/typesafe/netty/HandlerSubscriberWhiteboxVerificationTest.java
+++ b/netty-reactive-streams/src/test/java/com/typesafe/netty/HandlerSubscriberWhiteboxVerificationTest.java
@@ -1,7 +1,6 @@
 package com.typesafe.netty;
 
 import io.netty.channel.*;
-import io.netty.channel.local.LocalEventLoopGroup;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Promise;
 import org.reactivestreams.Subscriber;
@@ -18,7 +17,7 @@ public class HandlerSubscriberWhiteboxVerificationTest extends SubscriberWhitebo
         super(new TestEnvironment());
     }
 
-    private LocalEventLoopGroup eventLoop;
+    private DefaultEventLoopGroup eventLoop;
 
     // I tried making this before/after class, but encountered a strange error where after 32 publishers were created,
     // the following tests complained about the executor being shut down when I registered the channel. Though, it
@@ -26,7 +25,7 @@ public class HandlerSubscriberWhiteboxVerificationTest extends SubscriberWhitebo
     @BeforeMethod
     public void startEventLoop() {
         workAroundIssue277 = false;
-        eventLoop = new LocalEventLoopGroup();
+        eventLoop = new DefaultEventLoopGroup();
     }
 
     @AfterMethod

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.typesafe.netty</groupId>
     <artifactId>netty-reactive-streams-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Netty Reactive Streams Parent POM</name>
     <description>Reactive streams implementation for Netty.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.typesafe.netty</groupId>
     <artifactId>netty-reactive-streams-parent</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>Netty Reactive Streams Parent POM</name>
     <description>Reactive streams implementation for Netty.</description>
@@ -77,14 +77,14 @@
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-stream_2.11</artifactId>
-                <version>1.0</version>
+                <version>${akka-stream.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.0.41.Final</netty.version>
+        <netty.version>4.1.4.Final</netty.version>
         <reactive-streams.version>1.0.0</reactive-streams.version>
         <akka-stream.version>2.4.10</akka-stream.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.4.Final</netty.version>
+        <netty.version>4.1.5.Final</netty.version>
         <reactive-streams.version>1.0.0</reactive-streams.version>
         <akka-stream.version>2.4.10</akka-stream.version>
     </properties>


### PR DESCRIPTION
Actually this upgrades Netty and Akka Streams.
Tests actually running fine locally and I changed the objects to match the new Netty interfaces, actually Netty 4.1 is nearly binary compatible.
Actually this is useful to use gRPC with Play!

Maybe we can use this to make a netty-reactive-streams 1.1.0 so that we have a starting point for netty 4.1.

**Edit:** With https://github.com/AsyncHttpClient/async-http-client/tree/new-netty-4.1 it could actually run the full Play! master test suite. Eventually async-http-client has a bug in his websocket module, but Play won't use that, so..