### PR TITLE
Upgrades Netty & Akka

### DIFF
--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-stream_2.11</artifactId>
-            <version>2.4.2</version>
+            <version>${akka-stream.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.0.36.Final</netty.version>
+        <netty.version>4.0.39.Final</netty.version>
         <reactive-streams.version>1.0.0</reactive-streams.version>
-        <akka-stream.version>2.4.2</akka-stream.version>
+        <akka-stream.version>2.4.8</akka-stream.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Actually Netty 4.0.37.Final and 4.0.38.Final were 'broken' for netty-reactive-streams
So the best thing we can do is just to raise the version straight to 4.0.39.Final