### PR TITLE
Upgrade Netty to version 4.0.43.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.0.41.Final</netty.version>
+        <netty.version>4.0.43.Final</netty.version>
         <reactive-streams.version>1.0.0</reactive-streams.version>
         <akka-stream.version>2.4.10</akka-stream.version>
     </properties>


### PR DESCRIPTION
In light of https://github.com/playframework/playframework/pull/6886#issuecomment-273861951 and therefore preparation of upgrading netty in playframework/playframework, this change bumps the Netty version here first.