### PR TITLE
Upgrade Netty to version 4.0.51.final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.0.43.Final</netty.version>
+        <netty.version>4.0.51.Final</netty.version>
         <reactive-streams.version>1.0.0</reactive-streams.version>
         <akka-stream.version>2.4.10</akka-stream.version>
     </properties>


### PR DESCRIPTION
This matches the version in the newest version of `AsyncHttpClient`. Would love to see this released as 1.0.9 :)