### PR TITLE
Add Automatic-Module-Name in manifest

### DIFF
--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -38,4 +38,29 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive combine.children="append">
+                                <manifestEntries>
+                                    <Automatic-Module-Name>com.typesafe.netty.http</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/netty-reactive-streams/pom.xml
+++ b/netty-reactive-streams/pom.xml
@@ -32,4 +32,29 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive combine.children="append">
+                                <manifestEntries>
+                                    <Automatic-Module-Name>com.typesafe.netty.core</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Add Automatic-Module-Name in manifest so Java9 modular applications can depend on this library. 

* Fixes https://github.com/playframework/netty-reactive-streams/issues/39
* Using ```com.typesafe.netty.core``` as module name for netty-reactive-streams instead of ```com.typesafe.netty``` as it is too broad. Its also useful to keep it open in case you want to support more sub modules under ```com.typesafe.netty``` namespace like ```com.typesafe.netty.nio``` or something like that
* [This article](http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html) has best naming practices for JPMS modules. Let me know if you have better naming suggestions.

Verfied the manifest.mf file in the generated jar contains the "Automatic-Module-Name" header.

