### PR TITLE
Remove "testng" from non test scope

### DIFF
--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -30,6 +30,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/netty-reactive-streams/pom.xml
+++ b/netty-reactive-streams/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
We are getting a security vulnerability flagged on the dependencies of this module via this path:
com.typesafe.netty:netty-reactive-streams@1.0.8 › org.testng:testng@6.9.4 › org.beanshell:bsh@2.0b4
The interesting part of that was why there is a dependency on testng in production.

Having searched, apparently it's [only used in test](https://github.com/playframework/netty-reactive-streams/search?q=testng&unscoped_q=testng) here, so I thought it was worth feeding that back as a possible improvement in dependencies.