### PR TITLE
Fix "Apache License, Version 2.0" spelling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <licenses>
         <license>
-            <name>Apache 2</name>
+            <name>Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
There are many Java libraries licensed under "Apache License, Version 2.0" that do not use its official spelling.
This causes issues like https://issues.apache.org/jira/browse/MPIR-382: with every library defining its own spelling, it's difficult in large projects to have a clear view of all licenses in use.
This PR changes the license spelling to the official one, as advised by Maven developers.