### PR TITLE
[2.0.x]: Bump netty.version from 4.1.44.Final to 4.1.45.Final (and Akka 2.6.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <properties>
         <netty.version>4.1.45.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
-        <akka-stream.version>2.6.0</akka-stream.version>
+        <akka-stream.version>2.6.3</akka-stream.version>
         <maven-bundle-plugin.version>3.5.1</maven-bundle-plugin.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.43.Final</netty.version>
+        <netty.version>4.1.45.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <akka-stream.version>2.6.0</akka-stream.version>
         <maven-bundle-plugin.version>3.5.1</maven-bundle-plugin.version>


### PR DESCRIPTION
Backports #65 and #66