### PR TITLE
Change snapshot version on main branch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: release-drafter/release-drafter@v5
         with:
           name: "Netty Reactive Streams $RESOLVED_VERSION"
-          config-name: release-drafts/increasing-major-version.yml # located in .github/ in the default branch within this or the .github repo
+          config-name: release-drafts/increasing-minor-version.yml # located in .github/ in the default branch within this or the .github repo
           commitish: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/netty-reactive-streams-http/pom.xml
+++ b/netty-reactive-streams-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams-parent</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-reactive-streams-http</artifactId>

--- a/netty-reactive-streams/pom.xml
+++ b/netty-reactive-streams/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.typesafe.netty</groupId>
         <artifactId>netty-reactive-streams-parent</artifactId>
-        <version>2.0.5-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netty-reactive-streams</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.typesafe.netty</groupId>
     <artifactId>netty-reactive-streams-parent</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>Netty Reactive Streams Parent POM</name>
     <description>Reactive streams implementation for Netty.</description>


### PR DESCRIPTION
So we don't make a mistake on the next release. 2.0.5/2.0.6/... are cut from the 2.0.x branch