### PR TITLE
Drop Java 8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '11', '17' ]
         os: [ 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.5</version>
+                <version>7.6.1</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
On top of #149, which require Java 8, but "only" for test scope.

Actually, since this library doesn't really depend on Play itself and afaik is also used outside of the Play ecosystem, we might can continue publishing with Java 8. I keep it open for now, we can merge later.