### PR TITLE
Release reference to HttpStreamsServerHandler.lastRequest when possible

### DIFF
--- a/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsServerHandler.java
+++ b/netty-reactive-streams-http/src/main/java/com/typesafe/netty/http/HttpStreamsServerHandler.java
@@ -113,6 +113,11 @@ public class HttpStreamsServerHandler extends HttpStreamsHandler<HttpRequest, Ht
         if (close) {
             ctx.close();
         }
+
+        // release reference to lastRequest when there are no in flight requests so it can be GC'd
+        if (inFlight == 0) {
+            lastRequest = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
When using idleTimeout configuration in a play application, the HttpStreamsServerHandler keeps a reference to lastRequest, and lastRequest can be relatively large (10kb).  When there are many open idle connections, lastRequest heap usage can add up, even though the data is not used (lastRequest will be reassigned to a new value when serving the next request).

This change sets lastRequest to null to allow the HttpRequest to be GC'd even if HttpStreamsServerHandler is kept in the heap.

To test I deployed this change in my play application and observed the heap dump before/after the change.  The idle connections take a lot less heap space now.  Existing unit tests in HttpStreamsTest continue to pass.