### PR TITLE
Avoid NPE in HandlerPublisher.complete()

### DIFF
--- a/netty-reactive-streams/src/main/java/com/typesafe/netty/HandlerPublisher.java
+++ b/netty-reactive-streams/src/main/java/com/typesafe/netty/HandlerPublisher.java
@@ -405,7 +405,9 @@ public class HandlerPublisher<T> extends ChannelDuplexHandler implements Publish
                 break;
             case DEMANDING:
             case IDLE:
-                subscriber.onComplete();
+                if (subscriber != null) {
+                    subscriber.onComplete();
+                }
                 state = DONE;
                 break;
             case NO_SUBSCRIBER_ERROR:


### PR DESCRIPTION
As described in #164, I see a NPE in complete() that I believe is caused by a race here onComplete() is called in between where provideChannelContext() sets state to IDLE and when subscriber.onSubscribe() gets around to setting the subscriber. A full fix to that race is tricky, but this null check is safe. That race could leave the publisher in a bad state, but since the handler has been removed by that point, it shouldn't matter.

fixes #164