### PR TITLE
[3.0.x] Fix wrong netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <pekko-stream.version>1.6.0</pekko-stream.version>
         <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>


### PR DESCRIPTION
Merged too fast: https://github.com/playframework/netty-reactive-streams/pull/594